### PR TITLE
Add task definition and update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,23 @@
   "extends": [
     "config:recommended"
   ],
+
+  "tekton": {
+    "fileMatch": ["\\.yaml$", "\\.yml$"],
+    "includePaths": [
+      "tasks/**",
+    ]
+  },
+
   "docker-compose": {
     "fileMatch": ["^container-compose\\.yaml$"]
   },
+
   "packageRules": [
     {
       "matchPackageNames": ["mariadb"],
       "allowedVersions": "<11.5.0",
       "versioning": "docker"
     }
-  ]
+  ],
 }

--- a/tasks/simple.yaml
+++ b/tasks/simple.yaml
@@ -1,0 +1,8 @@
+
+definition:
+- name: build
+  image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
+- name: next-step
+  env:
+  - name: BUILDER_IMAGE
+    value: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050


### PR DESCRIPTION
The updated renovate config is expected to update buildah image in the both image and value fields.